### PR TITLE
bug fix for table without style node

### DIFF
--- a/lib/omnidocx.rb
+++ b/lib/omnidocx.rb
@@ -299,7 +299,10 @@ module Omnidocx
           #updating the stlye ids in the table elements present in the document content XML
           doc_content = doc_cnt == 0 ? @main_body : Nokogiri::XML(zip_file.read(DOCUMENT_FILE_PATH))
           doc_content.xpath("//w:tbl").each do |tbl_node|
-            val_attr = tbl_node.xpath('.//w:tblStyle').last.attributes['val']
+            style_node = tbl_node.xpath('.//w:tblStyle').last
+            next unless style_node
+
+            val_attr = style_node.attributes['val']
             table_hash["doc#{doc_cnt}"][val_attr.value.to_s] = tbl_cnt
             val_attr.value = val_attr.value.gsub(/[0-9]+/, tbl_cnt.to_s)
             tbl_cnt += 1


### PR DESCRIPTION
When document contains table without style, script throws
`gems/omnidocx-0.1.3/lib/omnidocx.rb:302:in `block (3 levels) in merge_documents': undefined method `attributes' for nil:NilClass (NoMethodError)`
exception.